### PR TITLE
DEV-42 Change the way the dictionary is used in the spellchecker

### DIFF
--- a/doc/tex/check-spelling.sh
+++ b/doc/tex/check-spelling.sh
@@ -2,13 +2,11 @@
 
 SpellCheck() {
     filename=$1.spellcheck
-    cat $1 | aspell --lang=en --mode=tex list | aspell --lang=es --mode=tex --personal=./dictionary.rws list | sort > $filename
+    cat $1 | aspell --lang=en --mode=tex list | aspell --lang=es --mode=tex --personal=./dictionary.txt list | sort > $filename
     output=$(cat $filename | wc -l)
 }
 
 errors=false
-
-aspell --lang=es create master ./dictionary.rws < dictionary.txt
 
 for file in $(find . -name "*.tex"); do
     SpellCheck $file

--- a/doc/tex/check-spelling.sh
+++ b/doc/tex/check-spelling.sh
@@ -2,7 +2,7 @@
 
 SpellCheck() {
     filename=$1.spellcheck
-    cat $1 | aspell --lang=en --mode=tex list | aspell --lang=es --mode=tex --extra-dicts=./dictionary.rws list | sort > $filename
+    cat $1 | aspell --lang=en --mode=tex list | aspell --lang=es --mode=tex --personal=./dictionary.rws list | sort > $filename
     output=$(cat $filename | wc -l)
 }
 

--- a/doc/tex/dictionary.txt
+++ b/doc/tex/dictionary.txt
@@ -1,5 +1,10 @@
+personal_ws-1.1 es 0 utf-8
+
 biblio
 colorlinks
 linkcolor
 urlcolor
 Matroos
+Ángel
+Gómez
+Martín

--- a/doc/tex/dictionary.txt
+++ b/doc/tex/dictionary.txt
@@ -1,5 +1,4 @@
 personal_ws-1.1 es 0 utf-8
-
 biblio
 colorlinks
 linkcolor

--- a/doc/tex/proyecto.tex
+++ b/doc/tex/proyecto.tex
@@ -27,7 +27,7 @@
 \pagestyle{fancyplain} % Makes all pages in the document conform to the custom headers and footers
 \fancyhead[L]{} % Empty left header
 \fancyhead[C]{} % Empty center header
-\fancyhead[R]{Me Llamo Así} % My name
+\fancyhead[R]{Ángel Gómez Martín} % My name
 \fancyfoot[L]{} % Empty left footer
 \fancyfoot[C]{} % Empty center footer
 \fancyfoot[R]{\thepage} % Page numbering for right footer


### PR DESCRIPTION
This PR closes #42.

See the issue description for more info.

The PR modifies the dictionary file and the execution of `aspell` in the script. + Added a few words with accents to test that the new dictionary work fine.